### PR TITLE
Update for new hOn login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="pyhOn",
-    version="0.17.4",
+    version="0.17.5",
     author="Andre Basche",
     description="Control hOn devices with python",
     long_description=long_description,


### PR DESCRIPTION
https://github.com/Andre0512/hon/issues/230

It looks like the first URL gives us a different URL back, that is also relative.
This URL takes us to a NEW login page, so I force us back to the old one for now.
It also looks like there used to be more redirects, and now there are less?

Anyway, this code should work for both the OLD and NEW auth methods as far as I can tell