### PR TITLE
fix: call `load_attributes` before `load_commands`

### DIFF
--- a/pyhon/hon.py
+++ b/pyhon/hon.py
@@ -92,8 +92,8 @@ class Hon:
         if appliance.mac_address == "":
             return
         try:
-            await appliance.load_commands()
             await appliance.load_attributes()
+            await appliance.load_commands()
             await appliance.load_statistics()
         except (KeyError, ValueError, IndexError) as error:
             _LOGGER.exception(error)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="pyhOn",
-    version="0.17.5",
+    version="0.17.6",
     author="Andre Basche",
     description="Control hOn devices with python",
     long_description=long_description,


### PR DESCRIPTION
This pull request includes changes to the `pyhon` project, focusing on correcting the order of asynchronous method calls and updating the package version.

Improvements to method execution order:

* [`python/hon.py`](diffhunk://#diff-4793c1e9466d9465e6bbf74876be66148f3918a1441197d285f9a04fd7b327cfL95-R96): Moved the `await appliance.load_commands()` call to ensure it executes before `await appliance.load_attributes()` for proper command loading.

ℹ️ Otherwise the settings command will retain the default value instead of the real ones in attributes:
The [`sync_params_to_command`](https://github.com/Andre0512/pyhOn/blob/59e3d9949f8a342e05daba70451196e7497cacb2/pyhon/appliance.py#L194) called in `load_commands` will not find the real data in attributes ([ref](https://github.com/Andre0512/pyhOn/blob/59e3d9949f8a342e05daba70451196e7497cacb2/pyhon/appliance.py#L276-L279)) if not loaded before

Package version update:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L10-R10): Updated the version from `0.17.5` to `0.17.6` to reflect the latest changes.

Fixes https://github.com/Andre0512/hon/issues/238