### PR TITLE
Add jwt token support

### DIFF
--- a/pyhon/connection/handler/hon.py
+++ b/pyhon/connection/handler/hon.py
@@ -58,7 +58,7 @@ class HonConnectionHandler(ConnectionHandler):
         return self
 
     async def _check_headers(self, headers: Dict[str, str]) -> Dict[str, str]:
-        if self._refresh_token:
+        if self._refresh_token and self.auth.token_expires_soon:
             await self.auth.refresh(self._refresh_token)
         if not (self.auth.cognito_token and self.auth.id_token):
             await self.auth.authenticate()

--- a/pyhon/parameter/enum.py
+++ b/pyhon/parameter/enum.py
@@ -48,4 +48,4 @@ class HonParameterEnum(HonParameter):
             self._value = value
             self.check_trigger(value)
         else:
-            raise ValueError(f"Allowed values: {self._values} But was: {value}")
+            raise ValueError(f"Allowed values for {self.key}: {self._values} But was: {value}")


### PR DESCRIPTION
This should increase the reliability in case haier ever decides to change the expiration time.

I also added a check for the token expires soon in the refresh_token call, this should avoid unecessary login calls (before this patch there were around 40 login calls while using the example code from the readme, so simply requesting the info)

And furthermore increased the clarity for the logging of enum errors.